### PR TITLE
fix: split by bachslash on windows using path.sep, close #5

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { sep } from 'path'
 import { blue, bold, gray, green, inverse, magenta, yellow } from 'picocolors'
 
 export interface TreeNode<T> {
@@ -32,7 +33,7 @@ function pathListToTree<T>(data: [string, T][]): TreeNode<T>[] {
   const tree: TreeNode<T>[] = []
   for (let i = 0; i < data.length; i++) {
     const path: string = data[i][0]
-    const split: string[] = path.split('/')
+    const split: string[] = path.split(sep)
     createNode(split, tree, data[i][1])
   }
   return tree
@@ -72,7 +73,7 @@ function renderTreeNode(node: TreeNode<number>, indent = '', prefix = '├─', 
   if (node.children.length === 1) {
     return renderTreeNode({
       ...node.children[0],
-      name: `${node.name}/${node.children[0].name}`,
+      name: `${node.name}${sep}${node.children[0].name}`,
     }, indent, prefix, prevLast)
   }
   return [

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,9 @@ function _onOpen(path: string) {
     return
   if (HIDE_NODE_MODULES && path.includes('node_modules'))
     return
-  const abs = resolve(process.cwd(), path)
+  // remove messy leading '\\' or '\\\\?\\' Universal Naming Convention (UNC) prefix in windows' file path
+  const normalizedPath = path.replace(/\\\\*\??\\+/, '')
+  const abs = resolve(process.cwd(), normalizedPath)
   _listeners.forEach(fn => fn(abs))
   console.log(openBadge, abs)
   counter.set(abs, (counter.get(abs) || 0) + 1)


### PR DESCRIPTION
file path splitting in 'pathListToTree' fail by splitting on '/' instead of backslash '' on windows, use path.sep to split instead

close #5