### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "@antfu/ni": "^0.14.0",
     "@antfu/utils": "^0.5.1",
     "@types/node": "^17.0.23",
+    "ansis": "^3.12.0",
     "bumpp": "^7.1.1",
     "eslint": "^8.13.0",
     "esno": "^0.14.1",
     "fast-glob": "^3.2.11",
     "path-list-to-tree": "^1.1.1",
-    "picocolors": "^1.0.0",
     "pkgroll": "^1.0.4",
     "typescript": "^4.6.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,12 @@ specifiers:
   '@antfu/ni': ^0.14.0
   '@antfu/utils': ^0.5.1
   '@types/node': ^17.0.23
+  ansis: ^3.12.0
   bumpp: ^7.1.1
   eslint: ^8.13.0
   esno: ^0.14.1
   fast-glob: ^3.2.11
   path-list-to-tree: ^1.1.1
-  picocolors: ^1.0.0
   pkgroll: ^1.0.4
   typescript: ^4.6.3
 
@@ -19,12 +19,12 @@ devDependencies:
   '@antfu/ni': 0.14.0
   '@antfu/utils': 0.5.1
   '@types/node': 17.0.23
+  ansis: 3.12.0
   bumpp: 7.1.1
   eslint: 8.13.0
   esno: 0.14.1
   fast-glob: 3.2.11
   path-list-to-tree: 1.1.1
-  picocolors: 1.0.0
   pkgroll: 1.0.4_typescript@4.6.3
   typescript: 4.6.3
 
@@ -510,6 +510,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /ansis/3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
     dev: true
 
   /argparse/2.0.1:
@@ -2546,10 +2551,6 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
-
-  /picocolors/1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
 
   /picomatch/2.3.0:

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { sep } from 'path'
-import { blue, bold, gray, green, inverse, magenta } from 'picocolors'
+import { blue, gray, green, magenta } from 'ansis'
 
 export interface TreeNode<T> {
   name: string
@@ -39,7 +39,7 @@ function pathListToTree<T>(data: [string, T][]): TreeNode<T>[] {
 
 export function displayBadge() {
   console.log()
-  console.log(inverse(bold(magenta(' FSSPY '))) + magenta(' Summary'))
+  console.log(magenta.bold.inverse(' FSSPY ') + magenta(' Summary'))
 }
 
 export function displayTree(entries: [string, number][], root = '', message = '') {
@@ -75,7 +75,7 @@ function renderTreeNode(node: TreeNode<number>, indent = '', prefix = '├─', 
     }, indent, prefix, prevLast)
   }
   return [
-    (node.name ? `${gray(`${indent}${prefix} `)}${node.name}` : '') + (node.data ? green(` x${node.data}`) : ''),
+    (node.name ? `${gray`${indent}${prefix} `}${node.name}` : '') + (node.data ? green` x${node.data}` : ''),
     ...renderTreeNodes(node.children, indent, prevLast),
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path'
 import { writeFileSync } from 'fs'
 import { partition } from '@antfu/utils'
-import { yellow } from 'picocolors'
+import { yellow } from 'ansis'
 import { displayBadge, displayTree } from './display'
 
 // make them configurable by env
@@ -64,7 +64,7 @@ function _onEvent(event: FileSystemEvent, path: string) {
   eventsLog.push(log)
   _listeners.forEach(fn => fn(...log))
   if (LOG)
-    console.log(yellow(`[fs.${event}]`), abs)
+    console.log(yellow`[fs.${event}]`, abs)
   counter.set(abs, (counter.get(abs) || 0) + 1)
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).


## Test

Before test run `pnpm run build`.

Then run `pnpm start`.

Outputs:

![image](https://github.com/user-attachments/assets/bd3e3d16-b49e-41ba-a24a-6d7012e98cc3)
